### PR TITLE
Fix removeDrawToolbar(clearFeatures = TRUE) #61

### DIFF
--- a/R/draw.R
+++ b/R/draw.R
@@ -26,6 +26,7 @@ drawDependencies <- function() {
 #' @param rectangleOptions See \code{\link{drawRectangeOptions}}(). Set to FALSE to disable rectangle drawing.
 #' @param markerOptions See \code{\link{drawMarkerOptions}}(). Set to FALSE to disable marker drawing.
 #' @param editOptions By default editing is disable. To enable editing pass \code{\link{editToolbarOptions}}().
+#' @param singleFeature When set to TRUE, only one feature can be drawn at a time, the previous ones being removed.
 #' @export
 #' @rdname draw
 addDrawToolbar <- function(
@@ -36,7 +37,8 @@ addDrawToolbar <- function(
   circleOptions = drawCircleOptions(),
   rectangleOptions = drawRectangeOptions(),
   markerOptions = drawMarkerOptions(),
-  editOptions = FALSE
+  editOptions = FALSE,
+  singleFeature = FALSE
 ) {
 
   if(!is.null(targetGroup) && !is.null(targetLayerId)) {
@@ -68,7 +70,8 @@ addDrawToolbar <- function(
       polygon = polygonOptions,
       circle = circleOptions,
       rectangle = rectangleOptions,
-      marker = markerOptions )),
+      marker = markerOptions,
+      singleFeature = singleFeature)),
     edit = editOptions )
 
   leaflet::invokeMethod(map, leaflet::getMapData(map), "addDrawToolbar",

--- a/inst/htmlwidgets/lib/draw/draw-bindings.js
+++ b/inst/htmlwidgets/lib/draw/draw-bindings.js
@@ -191,7 +191,8 @@ LeafletWidget.methods.removeDrawToolbar = function(clearFeatures) {
       delete map.drawToolbar;
     }
     if(map._editableFeatureGroupName && clearFeatures) {
-      map.layerManager.clearGroup(map._editableFeatureGroupName);
+      featureGroup = map.layerManager.getLayerGroup(map._editableFeatureGroupName, false)
+      featureGroup.clearLayers();
     }
     map._editableFeatureGroupName = null;
     if(map._editableGeoJSONLayerId && clearFeatures) {

--- a/inst/htmlwidgets/lib/draw/draw-bindings.js
+++ b/inst/htmlwidgets/lib/draw/draw-bindings.js
@@ -82,6 +82,12 @@ LeafletWidget.methods.addDrawToolbar = function(targetLayerId, targetGroup, opti
     });
 
     map.on(L.Draw.Event.CREATED, function (e) {
+      if (options.draw.singleFeature){
+  		  if (editableFeatureGroup.getLayers().length > 0) {
+          editableFeatureGroup.clearLayers();
+  		  }
+      }
+
       var layer = e.layer;
       editableFeatureGroup.addLayer(layer);
 


### PR DESCRIPTION
The clearGroup() seems to be a custom function, not in base leaflet, and doesn't seems to work as expected. Replacing it with raw/base leaflet