### PR TITLE
WIP - handle Leaflet.draw add/delete with R leaflet layerManger

### DIFF
--- a/inst/htmlwidgets/lib/draw/draw-bindings.js
+++ b/inst/htmlwidgets/lib/draw/draw-bindings.js
@@ -89,7 +89,6 @@ LeafletWidget.methods.addDrawToolbar = function(targetLayerId, targetGroup, opti
       }
 
       var layer = e.layer;
-      editableFeatureGroup.addLayer(layer);
 
       // assign a unique key to the newly created feature
       var featureId = L.stamp(layer);
@@ -106,6 +105,15 @@ LeafletWidget.methods.addDrawToolbar = function(targetLayerId, targetGroup, opti
       if(typeof layer.getRadius === 'function') {
         layer.feature.properties.radius = layer.getRadius();
       }
+debugger;
+      // add the newly drawn shape/feature to layerManager
+      //  so that can be used from R side methods
+      map.layerManager.addLayer(
+        layer,
+        null,  //category
+        String(L.stamp(layer)),  //layerId use stamp
+        targetGroup  //group which is targetGroup
+      );
 
       if (!HTMLWidgets.shinyMode) return;
 
@@ -174,6 +182,16 @@ LeafletWidget.methods.addDrawToolbar = function(targetLayerId, targetGroup, opti
         if(typeof layer.getRadius === 'function') {
           layer.feature.properties.radius = layer.getRadius();
         }
+
+
+        // remove the deleted shape/feature from layerManager
+        //  for proper R side methods
+        //  layerManager only supports removal with category and layerId
+        //  as far as I can tell
+        map.layerManager.removeLayer(
+          "null",  //category
+          String(L.stamp(layer)) // layerId - we used L.stamp
+        );
       });
 
       if (!HTMLWidgets.shinyMode) return;


### PR DESCRIPTION
 https://github.com/bhaskarvk/leaflet.extras/issues/96

Questions:

- [ ] R leaflet `layerManager` only supports full removal with the key combination of `category` and `layerId`.  I used category as `null` but we could easily use something like `draw` or even the same as `group`.  For `layerId`, I just used `String(L.stamp(layer))`.  I would make pull to R leaflet for other removal methods, but I know that acceptance might be slow.
- [ ] How might we assign a more knowable `layerId` to support removal of single layers?  I know that a user could monitor the Leaflet.draw events in Shiny to keep a list, but is there an easier way.
- [ ] How could this be used if we are editing existing features?  In this case the above might be much easier, since a user should know what `layerId` was assigned.

Code to demonstrate:

```
#devtools::install_github("timelyportfolio/leaflet.extras@draw-layermgr")

library(leaflet)
library(leaflet.extras)

leaflet() %>%
  addDrawToolbar(editOptions=editToolbarOptions())

library(shiny)
ui <- tagList(
  leafletOutput("leaf"),
  actionButton("btnclear", "clear drawn")
)
server <- function(input, output, session) {
  output$leaf <- renderLeaflet({
    leaflet() %>%
      addDrawToolbar(editOptions=editToolbarOptions())
  })
  
  observeEvent(
    input$btnclear,
    {
      leafletProxy("leaf") %>%
       clearGroup("editableFeatureGroup")
    }
  )
}
shinyApp(ui,server)

```
