### PR TITLE
Fix mismatch in option names in R / JS code

### DIFF
--- a/inst/htmlwidgets/lib/sharamov-leaflet-plugins/layer/tile/Bing-bindings.js
+++ b/inst/htmlwidgets/lib/sharamov-leaflet-plugins/layer/tile/Bing-bindings.js
@@ -3,10 +3,10 @@
 LeafletWidget.methods.addBingTiles = function(layerId, group, options) {
   (function(){
     var map = this;
-    var apikey = options.apikey;
-    delete options.apikey;
+    var apiKey = options.apiKey;
+    delete options.apiKey;
 
-    map.layerManager.addLayer(L.bingLayer(apikey, options), "tile", layerId, group);
+    map.layerManager.addLayer(L.bingLayer(apiKey, options), "tile", layerId, group);
 
   }).call(this);
 };


### PR DESCRIPTION
There is a discrepancy in option names for the Bing map tiles, which leads to the API key not being added to the URL
R code sends apiKey and JS code accepts options.apikey (no camel-casing).
I changed both to camel-casing since this seems to be more consistent.