### PR TITLE
Use whenReady leaflet method

### DIFF
--- a/R/mapUtils.R
+++ b/R/mapUtils.R
@@ -61,6 +61,14 @@ addResetMapButton <- function(map) {
     icon = "ion-arrow-shrink",
     title = "Reset View",
     onClick = JS("function(btn, map){ map.setView(map._initialCenter, map._initialZoom); }"))) %>%
-  htmlwidgets::onRender(JS("function(el, x){ var map = this; map._initialCenter = map.getCenter(); map._initialZoom = map.getZoom();}"))
-
+  htmlwidgets::onRender(JS(
+"
+function(el, x){ 
+  var map = this; 
+  map.whenReady(function(){
+    map._initialCenter = map.getCenter(); 
+    map._initialZoom = map.getZoom();
+  });
+}"
+  )) 
 }


### PR DESCRIPTION
Fixes https://github.com/rstudio/leaflet/issues/623
Fixes https://github.com/rstudio/leaflet/issues/608

Solves race case of trying to get a mapCenter when the widget has rendered, but the map has not rendered.

I have not looked for other situations where this might be useful within `leaflet.extras`.

Method: https://leafletjs.com/reference-1.3.0.html#map-whenready

